### PR TITLE
schedule-DOM

### DIFF
--- a/src/app/mock/schedule.ts
+++ b/src/app/mock/schedule.ts
@@ -1,0 +1,5 @@
+export const mockschedule = {
+  id: "member1",
+  name: "中澤",
+  schedule: {} as Record<string, number[]>,
+};

--- a/src/app/schedule/page.tsx
+++ b/src/app/schedule/page.tsx
@@ -20,7 +20,7 @@ export default function ScheduleManagementPage() {
   const [member, setMember] = useState(initialMember);
   const [startDate, setStartDate] = useState(() => new Date("2024-08-17"));
   const weekDates = getWeekDates(startDate);
-// on offを切り替える関数
+  // on offを切り替える関数
   const toggleHour = (day: string, hour: number) => {
     const hours = member.schedule?.[day] || [];
     const newHours = hours.includes(hour)
@@ -35,7 +35,30 @@ export default function ScheduleManagementPage() {
       },
     });
   };
-   
+
   const handleSave = () => {
     console.log("保存するスケジュール:", member);
   };
+  return (
+    <div className="p-6 flex flex-col items-center">
+      <h1 className="text-2xl font-bold mb-4">
+        {member.name} のスケジュール管理
+      </h1>
+
+      {/* 週切替 */}
+      <div className="flex items-center gap-4 mb-4">
+        <Button
+          size="icon"
+          variant="outline"
+          onClick={() => {
+            const newDate = new Date(startDate);
+            newDate.setDate(newDate.getDate() - 7);
+            setStartDate(newDate);
+          }}
+        >
+          <ChevronLeftIcon className="h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/schedule/page.tsx
+++ b/src/app/schedule/page.tsx
@@ -1,0 +1,5 @@
+"use client";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { ChevronLeftIcon, ChevronRightIcon } from "lucide-react";
+import { mockschedule as initialMember } from "../mock/schedule";

--- a/src/app/schedule/page.tsx
+++ b/src/app/schedule/page.tsx
@@ -58,6 +58,21 @@ export default function ScheduleManagementPage() {
         >
           <ChevronLeftIcon className="h-4 w-4" />
         </Button>
+        <div className="text-lg font-semibold">
+          {weekDates[0]} 〜 {weekDates[6]}
+        </div>
+
+        <Button
+          size="icon"
+          variant="outline"
+          onClick={() => {
+            const newDate = new Date(startDate);
+            newDate.setDate(newDate.getDate() + 7);
+            setStartDate(newDate);
+          }}
+        >
+          <ChevronRightIcon className="h-4 w-4" />
+        </Button>
       </div>
     </div>
   );

--- a/src/app/schedule/page.tsx
+++ b/src/app/schedule/page.tsx
@@ -94,6 +94,9 @@ export default function ScheduleManagementPage() {
           </div>
         ))}
       </div>
+      <Button onClick={handleSave} className="mt-6">
+        保存
+      </Button>
     </div>
   );
 }

--- a/src/app/schedule/page.tsx
+++ b/src/app/schedule/page.tsx
@@ -3,3 +3,15 @@ import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { ChevronLeftIcon, ChevronRightIcon } from "lucide-react";
 import { mockschedule as initialMember } from "../mock/schedule";
+
+const daysOfWeek = ["日", "月", "火", "水", "木", "金", "土"];
+// 曜日の関数
+function getWeekDates(startDate: Date): string[] {
+  const dates: string[] = [];
+  for (let i = 0; i < 7; i++) {
+    const d = new Date(startDate);
+    d.setDate(startDate.getDate() + i);
+    dates.push(`${d.getMonth() + 1}/${d.getDate()}`);
+  }
+  return dates;
+}

--- a/src/app/schedule/page.tsx
+++ b/src/app/schedule/page.tsx
@@ -74,26 +74,40 @@ export default function ScheduleManagementPage() {
           <ChevronRightIcon className="h-4 w-4" />
         </Button>
       </div>
-      {/* スケジュール表 */}
-      <div className="flex gap-6 overflow-x-auto px-8">
-        {weekDates.map((day, index) => (
-          <div key={day} className="flex flex-col items-center w-12">
-            <div className="font-bold text-sm mb-1">{daysOfWeek[index]}</div>
-            <div className="text-xs mb-2">{day}</div>
-            {Array.from({ length: 24 }, (_, hour) => (
-              <div
-                key={hour}
-                className={`w-full h-7 mb-[2px] cursor-pointer rounded-md ${
-                  member.schedule?.[day]?.includes(hour)
-                    ? "bg-cyan-500"
-                    : "bg-gray-200"
-                }`}
-                onClick={() => toggleHour(day, hour)}
-              />
-            ))}
-          </div>
-        ))}
+      <div className="flex overflow-x-auto px-8 gap-6">
+        {/* 左側：時間ラベル */}
+        <div className="flex flex-col items-end w-12 text-sm text-gray-600 font-medium">
+          <div className="h-[48px]" /> {/* 上の曜日+日付と高さ揃え */}
+          {Array.from({ length: 24 }, (_, hour) => (
+            <div key={hour} className="h-7 mb-[2px] pr-1">
+              {hour}:00
+            </div>
+          ))}
+        </div>
+
+        {/* 右側：各曜日列 */}
+        <div className="flex gap-4">
+          {weekDates.map((day, index) => (
+            <div key={day} className="flex flex-col items-center w-12">
+              <div className="font-bold text-sm mb-1">{daysOfWeek[index]}</div>
+              <div className="text-xs mb-2">{day}</div>
+              {Array.from({ length: 24 }, (_, hour) => (
+                <div
+                  key={hour}
+                  title={`${hour}:00`}
+                  className={`w-full h-7 mb-[2px] cursor-pointer rounded-md ${
+                    member.schedule?.[day]?.includes(hour)
+                      ? "bg-cyan-500"
+                      : "bg-gray-200"
+                  }`}
+                  onClick={() => toggleHour(day, hour)}
+                />
+              ))}
+            </div>
+          ))}
+        </div>
       </div>
+
       <Button onClick={handleSave} className="mt-6">
         保存
       </Button>

--- a/src/app/schedule/page.tsx
+++ b/src/app/schedule/page.tsx
@@ -74,6 +74,26 @@ export default function ScheduleManagementPage() {
           <ChevronRightIcon className="h-4 w-4" />
         </Button>
       </div>
+      {/* スケジュール表 */}
+      <div className="flex gap-6 overflow-x-auto px-8">
+        {weekDates.map((day, index) => (
+          <div key={day} className="flex flex-col items-center w-12">
+            <div className="font-bold text-sm mb-1">{daysOfWeek[index]}</div>
+            <div className="text-xs mb-2">{day}</div>
+            {Array.from({ length: 24 }, (_, hour) => (
+              <div
+                key={hour}
+                className={`w-full h-7 mb-[2px] cursor-pointer rounded-md ${
+                  member.schedule?.[day]?.includes(hour)
+                    ? "bg-cyan-500"
+                    : "bg-gray-200"
+                }`}
+                onClick={() => toggleHour(day, hour)}
+              />
+            ))}
+          </div>
+        ))}
+      </div>
     </div>
   );
 }

--- a/src/app/schedule/page.tsx
+++ b/src/app/schedule/page.tsx
@@ -15,3 +15,27 @@ function getWeekDates(startDate: Date): string[] {
   }
   return dates;
 }
+
+export default function ScheduleManagementPage() {
+  const [member, setMember] = useState(initialMember);
+  const [startDate, setStartDate] = useState(() => new Date("2024-08-17"));
+  const weekDates = getWeekDates(startDate);
+// on offを切り替える関数
+  const toggleHour = (day: string, hour: number) => {
+    const hours = member.schedule?.[day] || [];
+    const newHours = hours.includes(hour)
+      ? hours.filter((h) => h !== hour)
+      : [...hours, hour];
+
+    setMember({
+      ...member,
+      schedule: {
+        ...member.schedule,
+        [day]: newHours,
+      },
+    });
+  };
+   
+  const handleSave = () => {
+    console.log("保存するスケジュール:", member);
+  };

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -38,7 +38,7 @@ const Header = () => {
         </button>
         <button
           className="cursor-pointer rounded p-4 hover:bg-black/5"
-          onClick={() => handleClick("/group")}
+          onClick={() => handleClick("/schedule")}
         >
           <Image src="/users.svg" alt="users Icon" width={64} height={64} />
         </button>

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -27,7 +27,7 @@ const Header = () => {
         </button>
         <button
           className="cursor-pointer rounded p-4 hover:bg-black/5"
-          onClick={() => handleClick("/calendar")}
+          onClick={() => handleClick("/schedule")}
         >
           <Image
             src="/calendar.svg"
@@ -38,7 +38,7 @@ const Header = () => {
         </button>
         <button
           className="cursor-pointer rounded p-4 hover:bg-black/5"
-          onClick={() => handleClick("/schedule")}
+          onClick={() => handleClick("/group")}
         >
           <Image src="/users.svg" alt="users Icon" width={64} height={64} />
         </button>


### PR DESCRIPTION
## 具体的に何をしたのか
- スケジュール管理画面でメンバーの稼働時間帯（0〜23時）を曜日ごとに設定できるUIを実装した
- 曜日・時間スロットはクリックでON/OFF切り替え可能
- 週の切り替え機能（← / →）を追加し、1週間単位でスケジュールが編集可能
- 保存ボタンで現在の状態を `console.log()` 出力
- 横に何時か表記
- ホバーすると時間が表示される
## なぜこの変更方法を選択したのか、なぜこの変更で課題が解決するのか
- この変更により、UI上から直感的に稼働可能な時間帯を指定できるようになる
## どうやってこの変更を読めばいいのか
- `app/schedule/page.tsx`：スケジュール管理画面の本体
- `mock/member.ts`：初期メンバーデータ
- 時間スロットの ON/OFF ロジックは `toggleHour` 関数で実装
- カレンダーの週切り替えは `startDate` を基準に `getWeekDates()` で生成
## その他
